### PR TITLE
Fix issue when serviceEndpoint is an object

### DIFF
--- a/lib/verifier/WellKnownDidVerifier.ts
+++ b/lib/verifier/WellKnownDidVerifier.ts
@@ -249,13 +249,17 @@ export class WellKnownDidVerifier {
     if (!descriptor.serviceEndpoint)
       return Promise.reject({ status: ValidationStatusEnum.INVALID, message: WDCErrors.PROPERTY_SERVICE_ENDPOINT_NOT_PRESENT_IN_SERVICE })
 
-     // The object serviceEndpoint property can be a string and the value MUST be an origin string
-    if (new URL(descriptor.serviceEndpoint).origin !== descriptor.serviceEndpoint)
-      return Promise.reject({status: ValidationStatusEnum.INVALID, message: WDCErrors.PROPERTY_SERVICE_ENDPOINT_NOT_CONTAIN_VALID_ORIGIN})
-    if (new URL(descriptor.serviceEndpoint).protocol !== 'https:') return Promise.reject({
-      status: ValidationStatusEnum.INVALID,
-      message: WDCErrors.PROPERTY_ORIGIN_NOT_SECURE
-    })
+
+    if (typeof descriptor.serviceEndpoint === 'string') {
+      // The object serviceEndpoint property can be a string and the value MUST be an origin string
+      if (new URL(descriptor.serviceEndpoint).origin !== descriptor.serviceEndpoint)
+        return Promise.reject({ status: ValidationStatusEnum.INVALID, message: WDCErrors.PROPERTY_SERVICE_ENDPOINT_NOT_CONTAIN_VALID_ORIGIN })
+      if (new URL(descriptor.serviceEndpoint).protocol !== 'https:')
+        return Promise.reject({
+          status: ValidationStatusEnum.INVALID,
+          message: WDCErrors.PROPERTY_ORIGIN_NOT_SECURE
+        })
+    }
 
     if (typeof descriptor.serviceEndpoint === 'object') {
       // The object serviceEndpoint property can be an object which MUST contain an origins property
@@ -395,7 +399,14 @@ export class WellKnownDidVerifier {
    * @param descriptor The endpoint descriptor.
    */
   private getOrigins(descriptor: ServiceEndpoint): Array<string> {
-    return [descriptor.serviceEndpoint]
+    if (typeof descriptor.serviceEndpoint === 'string') {
+      return [descriptor.serviceEndpoint]
+    } else {
+      // This break with did-resolver@3
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return descriptor.serviceEndpoint.origins;
+    }
   }
 
 }

--- a/test/verifier.spec.ts
+++ b/test/verifier.spec.ts
@@ -125,6 +125,22 @@ describe('Domain Linkage Verifier', () => {
       expect(result.status).toEqual(ValidationStatusEnum.VALID);
     });
 
+    it('should verify when serviceEndpoint is an object containing an array of origins', async () => {
+      nock(ORIGIN).get('/.well-known/did-configuration.json').times(1).reply(200, DID_CONFIGURATION);
+
+      const endpointDescriptor: ServiceEndpoint = {
+        id: DID,
+        type: ServiceTypesEnum.LINKED_DOMAINS,
+        // This breaks the types in did-resolver@4
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        serviceEndpoint: { origins: [ORIGIN] },
+      };
+
+      const result = await verifier.verifyEndpointDescriptor({ descriptor: endpointDescriptor });
+      expect(result.status).toEqual(ValidationStatusEnum.VALID);
+    });
+
     it('should verify when serviceEndpoint is of type IServiceEndpoint', async () => {
       nock(ORIGIN).get('/.well-known/did-configuration.json').times(1).reply(200, DID_CONFIGURATION);
 


### PR DESCRIPTION
from the spec https://identity.foundation/.well-known/resources/did-configuration/#linked-domains

> The object MUST contain a serviceEndpoint property, and its value MUST be either an origin string **or an object that contains as origins property, the value of which MUST be an array of one or more** [origins](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy).

It seems this was supported in the code but a previous validation assumed the serviceEndpoint was an string, so the code failed before reaching in the object validation. I added tests for this case.

Please note that ServiceEndpoint in did-resolver@3 is string always, I tried to upgrade to v4 but that requires major changes.